### PR TITLE
Add descriptions for some enums

### DIFF
--- a/schemas/block_actions/explode.json
+++ b/schemas/block_actions/explode.json
@@ -13,12 +13,8 @@
 		},
 		"destruction_type": {
 			"description": "Determines if the explosion should destroy the terrain, destroy the terrain and drop the loot of the blocks, or none (\"destroy\", \"break\" or \"none\" respectively).",
-			"type": "string",
-			"enum": [
-				"destroy",
-				"break",
-				"none"
-			]
+			"$ref": "../shared/destruction_types.json",
+			"default": "break"
 		},
 		"damage_self": {
 			"description": "Determines if the exploding block should be affected by the summoned explosion.",

--- a/schemas/entity_actions/explode.json
+++ b/schemas/entity_actions/explode.json
@@ -14,11 +14,7 @@
 		"destruction_type": {
 			"description": "Determines if the explosion should destroy the terrain, destroy the terrain and drop the loot of the blocks, or none (\"destroy\", \"break\" or \"none\" respectively).",
 			"type": "string",
-			"enum": [
-				"destroy",
-				"break",
-				"none"
-			],
+			"$ref": "../shared/destruction_types.json",
 			"default": "break"
 		},
 		"damage_self": {

--- a/schemas/shared/action_result.json
+++ b/schemas/shared/action_result.json
@@ -1,12 +1,28 @@
 {
 	"$id": "https://snavesutit.github.io/origins-mod-schemas/",
 	"title": "Action Result",
+	"description": "A string used for determining the result of a certain action.",
 	"type": "string",
-	"enum": [
-		"consume_partial",
-		"consume",
-		"fail",
-		"pass",
-		"success"
+	"anyOf": [
+		{
+			"const": "consume_partial",
+			"description": "Indicates that the action is performed but the actor's hand is not swung and no statistic is incremented."
+		},
+		{
+			"const": "consume",
+			"description": "Indicates that the action is performed but the actor's hand is not swung."
+		},
+		{
+			"const": "fail",
+			"description": "Indicates that the action is not performed and prevents other actions from performing."
+		},
+		{
+			"const": "pass",
+			"description": "Indicates that the action is not performed but allows other actions from performing."
+		},
+		{
+			"const": "success",
+			"description": "Indicates that the action is performed and the actor's hand is swung."
+		}
 	]
 }

--- a/schemas/shared/destruction_types.json
+++ b/schemas/shared/destruction_types.json
@@ -1,0 +1,20 @@
+{
+	"$id": "https://snavesutit.github.io/origins-mod-schemas/",
+	"title": "Destruction Type",
+	"description": "A string that is used to determine the effect of an explosion to the terrain.",
+	"type": "string",
+	"anyOf": [
+		{
+			"const": "break",
+			"description": "The explosion will destroy the block(s) and drop the loot of the block(s)"
+		},
+		{
+			"const": "destroy",
+			"description": "The explosion will only destroy the block(s)."
+		},
+		{
+			"const": "none",
+			"description": "The explosion will not destroy the block(s) nor drop the loot table of the block(s)."
+		}
+	]
+}

--- a/schemas/shared/feature_renderer.json
+++ b/schemas/shared/feature_renderer.json
@@ -2,39 +2,138 @@
 	"$id": "https://snavesutit.github.io/origins-mod-schemas/",
 	"title": "Feature Renderer",
 	"type": "string",
-	"enum": [
-		"armor",
-		"cape",
-		"cat_collar",
-		"deadmau5",
-		"dolphin_held_item",
-		"drowned_overlay",
-		"elytra",
-		"enderman_block",
-		"energy_swirl_overlay",
-		"eyes",
-		"fox_held_item",
-		"head",
-		"held_item",
-		"horse_armor",
-		"horse_marking",
-		"iron_golem_crack",
-		"iron_golem_flower",
-		"llama_decor",
-		"mooshroom_mushroom",
-		"panda_held_item",
-		"saddle",
-		"sheep_wool",
-		"shoulder_parrot",
-		"shulker_head",
-		"slime_overlay",
-		"snowman_pumpkin",
-		"stray_overlay",
-		"stuck_objects",
-		"trident_riptide",
-		"tropical_fish_color",
-		"villager_clothing",
-		"villager_held_item",
-		"wolf_collar"
+	"anyOf": [
+		{
+			"const": "armor",
+			"description": "The armor that an entity is wearing."
+		},
+		{
+			"const": "cape",
+			"description": "The cape that a player might have."
+		},
+		{
+			"const": "cat_collar",
+			"description": "The collar of a tamed Cat."
+		},
+		{
+			"const": "deadmau5",
+			"description": "The mouse ears that the official Deadmau5 account has on its head."
+		},
+		{
+			"const": "dolphin_held_item",
+			"description": "The item the Dolphin is holding in their mouth when playing with the said item."
+		},
+		{
+			"const": "drowned_overlay",
+			"description": "The outer layer of the Drowned's texture (clothes, vegetation, etc.)."
+		},
+		{
+			"const": "elytra",
+			"description": "The elytra on the back of an entity. Also works for elytras from the Elytra Flight (Power Type)."
+		},
+		{
+			"const": "enderman_block",
+			"description": "The block an Enderman is holding."
+		},
+		{
+			"const": "energy_swirl_overlay",
+			"description": "The animated swirling texture that appears on (charged) a Creeper and Wither Boss (at half health)."
+		},
+		{
+			"const": "eyes",
+			"description": "The glow-in-the-dark eyes of a Spider, Cave Spider and Enderman."
+		},
+		{
+			"const": "fox_held_item",
+			"description": "The item that a Fox is holding in their mouth."
+		},
+		{
+			"const": "head",
+			"description": "The non-armor item in an entity's head armor slot."
+		},
+		{
+			"const": "held_item",
+			"description": "The item a humanoid entity is holding in their hands."
+		},
+		{
+			"const": "horse_armor",
+			"description": "The armor a Horse is wearing."
+		},
+		{
+			"const": "horse_marking",
+			"description": "The patterns of a Horse."
+		},
+		{
+			"const": "iron_golem_crack",
+			"description": "The cracks that appears when an Iron Golem is damaged."
+		},
+		{
+			"const": "iron_golem_flower",
+			"description": "The flowers that appears on an Iron Golem."
+		},
+		{
+			"const": "llama_decor",
+			"description": "The decorations that appears when a Llama is wearing a certain carpet."
+		},
+		{
+			"const": "mooshroom_mushroom",
+			"description": "The mushrooms on top of a Mooshroom."
+		},
+		{
+			"const": "panda_held_item",
+			"description": "The item that a Panda is holding."
+		},
+		{
+			"const": "saddle",
+			"description": "The saddle that appears when a Pig is wearing a saddle."
+		},
+		{
+			"const": "sheep_wool",
+			"description": "The wool coat of a Sheep."
+		},
+		{
+			"const": "shoulder_parrot",
+			"description": "The Parrots perching on a player."
+		},
+		{
+			"const": "shulker_head",
+			"description": "The head of a Shulker."
+		},
+		{
+			"const": "slime_overlay",
+			"description": "The translucent part of a Slime."
+		},
+		{
+			"const": "snowman_pumpkin",
+			"description": "The pumpkin of a Snow Golem."
+		},
+		{
+			"const": "stray_overlay",
+			"description": "The teared clothing of a Stray."
+		},
+		{
+			"const": "stuck_objects",
+			"description": "The objects that can get stuck to a player, like Arrows or Bee Stingers."
+		},
+		{
+			"const": "trident_riptide",
+			"description": "The animated swirling texture that appears when a player uses a Trident that has the Riptide enchantment."
+		},
+		{
+			"const": "tropical_fish_color",
+			"description": "The pattern on top of a Tropical Fish's base color."
+		},
+		{
+			"const": "villager_clothing",
+			"description": "The clothes of a Villager."
+		},
+		{
+			"const": "villager_held_item",
+			"description": "The item that a Villager is holding."
+		},
+		{
+			"const": "wolf_collar",
+			"description": "The collar of a tamed Wolf."
+		}
 	]
 }

--- a/schemas/shared/fluid_handling.json
+++ b/schemas/shared/fluid_handling.json
@@ -1,11 +1,20 @@
 {
 	"$id": "https://snavesutit.github.io/origins-mod-schemas/",
 	"title": "Fluid Handling",
-	"description": "A String used mainly for ray-casting to determine how it will handle fluids.",
+	"description": "A string used mainly for ray-casting to determine how it will handle fluids.",
 	"type": "string",
-	"enum": [
-		"any",
-		"none",
-		"source_only"
+	"anyOf": [
+		{
+			"const": "any",
+			"description": "The ray will stop at both flowing and source fluids."
+		},
+		{
+			"const": "none",
+			"description": "The ray will not stop at both flowing and source fluids."
+		},
+		{
+			"const": "source_only",
+			"description": "The ray will only stop at source fluids."
+		}
 	]
 }

--- a/schemas/shared/shape_type.json
+++ b/schemas/shared/shape_type.json
@@ -1,11 +1,20 @@
 {
 	"$id": "https://snavesutit.github.io/origins-mod-schemas/",
 	"title": "Shape Type",
-	"description": "A String used mainly for ray-casting to determine how it will handle blocks.",
+	"description": "A string used mainly for ray-casting to determine how it will handle blocks.",
 	"type": "string",
-	"enum": [
-		"collider",
-		"outline",
-		"visual"
+	"anyOf": [
+		{
+			"const": "collider",
+			"description": "The ray will only stop at blocks that cannot be walked through."
+		},
+		{
+			"const": "outline",
+			"description": "The ray will take the shape of the block into account, only stopping if the ray has hit a face of the block."
+		},
+		{
+			"const": "visual",
+			"description": "The ray will only stop at blocks that are not see-through."
+		}
 	]
 }

--- a/src/schemas/block_actions/explode.yml
+++ b/src/schemas/block_actions/explode.yml
@@ -14,11 +14,8 @@ properties:
 
   destruction_type:
     description: Determines if the explosion should destroy the terrain, destroy the terrain and drop the loot of the blocks, or none ("destroy", "break" or "none" respectively).
-    type: string
-    enum:
-      - destroy
-      - break
-      - none
+    $ref: ../shared/destruction_types.json
+    default: break
 
   damage_self:
     description: Determines if the exploding block should be affected by the summoned explosion.

--- a/src/schemas/entity_actions/explode.yml
+++ b/src/schemas/entity_actions/explode.yml
@@ -15,10 +15,7 @@ properties:
   destruction_type:
     description: Determines if the explosion should destroy the terrain, destroy the terrain and drop the loot of the blocks, or none ("destroy", "break" or "none" respectively).
     type: string
-    enum:
-      - destroy
-      - break
-      - none
+    $ref: ../shared/destruction_types.json
     default: break
 
   damage_self:

--- a/src/schemas/shared/action_result.yml
+++ b/src/schemas/shared/action_result.yml
@@ -1,9 +1,19 @@
 $id: https://snavesutit.github.io/origins-mod-schemas/
 title: Action Result
+description: A string used for determining the result of a certain action.
 type: string
-enum:
-  - consume_partial
-  - consume
-  - fail
-  - pass
-  - success
+anyOf:
+  - const: consume_partial
+    description: Indicates that the action is performed but the actor's hand is not swung and no statistic is incremented.
+  
+  - const: consume
+    description: Indicates that the action is performed but the actor's hand is not swung.
+
+  - const: fail
+    description: Indicates that the action is not performed and prevents other actions from performing.
+
+  - const: pass
+    description: Indicates that the action is not performed but allows other actions from performing.
+
+  - const: success
+    description: Indicates that the action is performed and the actor's hand is swung.

--- a/src/schemas/shared/destruction_types.yml
+++ b/src/schemas/shared/destruction_types.yml
@@ -1,0 +1,13 @@
+$id: https://snavesutit.github.io/origins-mod-schemas/
+title: Destruction Type
+description: A string that is used to determine the effect of an explosion to the terrain.
+type: string
+anyOf:
+  - const: break
+    description: The explosion will destroy the block(s) and drop the loot of the block(s)
+
+  - const: destroy
+    description: The explosion will only destroy the block(s).
+
+  - const: none
+    description: The explosion will not destroy the block(s) nor drop the loot table of the block(s).

--- a/src/schemas/shared/feature_renderer.yml
+++ b/src/schemas/shared/feature_renderer.yml
@@ -1,37 +1,102 @@
 $id: https://snavesutit.github.io/origins-mod-schemas/
 title: Feature Renderer
 type: string
-enum:
-  - armor
-  - cape
-  - cat_collar
-  - deadmau5
-  - dolphin_held_item
-  - drowned_overlay
-  - elytra
-  - enderman_block
-  - energy_swirl_overlay
-  - eyes
-  - fox_held_item
-  - head
-  - held_item
-  - horse_armor
-  - horse_marking
-  - iron_golem_crack
-  - iron_golem_flower
-  - llama_decor
-  - mooshroom_mushroom
-  - panda_held_item
-  - saddle
-  - sheep_wool
-  - shoulder_parrot
-  - shulker_head
-  - slime_overlay
-  - snowman_pumpkin
-  - stray_overlay
-  - stuck_objects
-  - trident_riptide
-  - tropical_fish_color
-  - villager_clothing
-  - villager_held_item
-  - wolf_collar
+anyOf:
+  - const: armor
+    description: The armor that an entity is wearing.
+
+  - const: cape
+    description: The cape that a player might have.
+
+  - const: cat_collar
+    description: The collar of a tamed Cat.
+
+  - const: deadmau5
+    description: The mouse ears that the official Deadmau5 account has on its head.
+
+  - const: dolphin_held_item
+    description: The item the Dolphin is holding in their mouth when playing with the said item.
+
+  - const: drowned_overlay
+    description: The outer layer of the Drowned's texture (clothes, vegetation, etc.).
+
+  - const: elytra
+    description: The elytra on the back of an entity. Also works for elytras from the Elytra Flight (Power Type).
+
+  - const: enderman_block
+    description: The block an Enderman is holding.
+
+  - const: energy_swirl_overlay
+    description: The animated swirling texture that appears on (charged) a Creeper and Wither Boss (at half health).
+
+  - const: eyes
+    description: The glow-in-the-dark eyes of a Spider, Cave Spider and Enderman.
+
+  - const: fox_held_item
+    description: The item that a Fox is holding in their mouth.
+
+  - const: head
+    description: The non-armor item in an entity's head armor slot.
+
+  - const: held_item
+    description: The item a humanoid entity is holding in their hands.
+
+  - const: horse_armor
+    description: The armor a Horse is wearing.
+
+  - const: horse_marking
+    description: The patterns of a Horse.
+
+  - const: iron_golem_crack
+    description: The cracks that appears when an Iron Golem is damaged.
+
+  - const: iron_golem_flower
+    description: The flowers that appears on an Iron Golem.
+
+  - const: llama_decor
+    description: The decorations that appears when a Llama is wearing a certain carpet.
+
+  - const: mooshroom_mushroom
+    description: The mushrooms on top of a Mooshroom.
+
+  - const: panda_held_item
+    description: The item that a Panda is holding.
+
+  - const: saddle
+    description: The saddle that appears when a Pig is wearing a saddle.
+
+  - const: sheep_wool
+    description: The wool coat of a Sheep.
+
+  - const: shoulder_parrot
+    description: The Parrots perching on a player.
+
+  - const: shulker_head
+    description: The head of a Shulker.
+
+  - const: slime_overlay
+    description: The translucent part of a Slime.
+
+  - const: snowman_pumpkin
+    description: The pumpkin of a Snow Golem.
+
+  - const: stray_overlay
+    description: The teared clothing of a Stray.
+
+  - const: stuck_objects
+    description: The objects that can get stuck to a player, like Arrows or Bee Stingers.
+
+  - const: trident_riptide
+    description: The animated swirling texture that appears when a player uses a Trident that has the Riptide enchantment.
+
+  - const: tropical_fish_color
+    description: The pattern on top of a Tropical Fish's base color.
+
+  - const: villager_clothing
+    description: The clothes of a Villager.
+
+  - const: villager_held_item
+    description: The item that a Villager is holding.
+
+  - const: wolf_collar
+    description: The collar of a tamed Wolf.

--- a/src/schemas/shared/fluid_handling.yml
+++ b/src/schemas/shared/fluid_handling.yml
@@ -1,8 +1,13 @@
 $id: https://snavesutit.github.io/origins-mod-schemas/
 title: Fluid Handling
-description: A String used mainly for ray-casting to determine how it will handle fluids.
+description: A string used mainly for ray-casting to determine how it will handle fluids.
 type: string
-enum:
-  - any
-  - none
-  - source_only
+anyOf:
+  - const: any
+    description: The ray will stop at both flowing and source fluids.
+
+  - const: none
+    description: The ray will not stop at both flowing and source fluids.
+
+  - const: source_only
+    description: The ray will only stop at source fluids.

--- a/src/schemas/shared/shape_type.yml
+++ b/src/schemas/shared/shape_type.yml
@@ -1,8 +1,13 @@
 $id: https://snavesutit.github.io/origins-mod-schemas/
 title: Shape Type
-description: A String used mainly for ray-casting to determine how it will handle blocks.
+description: A string used mainly for ray-casting to determine how it will handle blocks.
 type: string
-enum:
-  - collider
-  - outline
-  - visual
+anyOf:
+  - const: collider
+    description: The ray will only stop at blocks that cannot be walked through.
+
+  - const: outline
+    description: The ray will take the shape of the block into account, only stopping if the ray has hit a face of the block.
+
+  - const: visual
+    description: The ray will only stop at blocks that are not see-through.


### PR DESCRIPTION
This PR adds a description for some enums used by certain power/action types that'll appear in the auto-completion tooltip for the fields that'll use the said enums.