### PR TITLE
Finished up Attribute Modifiers and Fixed Modify Stat

### DIFF
--- a/schemas/apoli/entity_actions/modify_stat.json
+++ b/schemas/apoli/entity_actions/modify_stat.json
@@ -16,8 +16,8 @@
 			]
 		},
 		"stat": {
-			"description": "The namespace and ID of the statistic to be modified.",
-			"$ref": "../../types/identifier.json"
+			"description": "The type and name of the statistic to be modified.",
+			"$ref": "../../types/stat.json"
 		},
 		"modifier": {
 			"description": "This modifier will be applied to the current value of the statistic specified.",

--- a/schemas/apoli/power_types/modify_food.json
+++ b/schemas/apoli/power_types/modify_food.json
@@ -27,24 +27,24 @@
 		},
 		"food_modifier": {
 			"description": "If specified, this modifier will apply to the food amount gained by eating a food item.",
-			"$ref": "../../types/attribute_modifier.json"
+			"$ref": "../../types/attribute_modifier_legacy.json"
 		},
 		"food_modifiers": {
 			"description": "If specified, these modifiers will apply to the food amount gained by eating a food item.",
 			"type": "array",
 			"items": {
-				"$ref": "../../types/attribute_modifier.json"
+				"$ref": "../../types/attribute_modifier_legacy.json"
 			}
 		},
 		"saturation_modifier": {
 			"description": "If specified, this modifier will apply to the saturation amount gained by eating a food item.",
-			"$ref": "../../types/attribute_modifier.json"
+			"$ref": "../../types/attribute_modifier_legacy.json"
 		},
 		"saturation_modifiers": {
 			"description": "If specified, these modifiers will apply to the saturation amount gained by eating a food item.",
 			"type": "array",
 			"items": {
-				"$ref": "../../types/attribute_modifier.json"
+				"$ref": "../../types/attribute_modifier_legacy.json"
 			}
 		},
 		"entity_action": {

--- a/schemas/apoli/power_types/modify_lava_speed.json
+++ b/schemas/apoli/power_types/modify_lava_speed.json
@@ -15,13 +15,13 @@
 		},
 		"modifier": {
 			"description": "If specified, this modifier will be applied to the movement speed while in lava.",
-			"$ref": "../../types/attribute_modifier.json"
+			"$ref": "../../types/attribute_modifier_legacy.json"
 		},
 		"modifiers": {
 			"description": "If specified, these modifiers will be applied to the movement speed while in lava.",
 			"type": "array",
 			"items": {
-				"$ref": "../../types/attribute_modifier.json"
+				"$ref": "../../types/attribute_modifier_legacy.json"
 			}
 		}
 	}

--- a/schemas/apoli/power_types/modify_swim_speed.json
+++ b/schemas/apoli/power_types/modify_swim_speed.json
@@ -15,13 +15,13 @@
 		},
 		"modifier": {
 			"description": "If specified, this modifier will apply to the swim speed.",
-			"$ref": "../../types/attribute_modifier.json"
+			"$ref": "../../types/attribute_modifier_legacy.json"
 		},
 		"modifiers": {
 			"description": "If specified, these modifiers will apply to the swim speed.",
 			"type": "array",
 			"items": {
-				"$ref": "../../types/attribute_modifier.json"
+				"$ref": "../../types/attribute_modifier_legacy.json"
 			}
 		}
 	}

--- a/schemas/types/attribute_modifier.json
+++ b/schemas/types/attribute_modifier.json
@@ -12,16 +12,37 @@
 			"enum": [
 				"addition",
 				"multiply_base",
-				"multiply_total"
+				"multiply_total",
+
+				"add_base_early",
+				"multiply_base_additive",
+				"multiply_base_multiplicative",
+				"add_base_late",
+				"min_base",
+				"max_base",
+				"set_base",
+				"multiply_total_additive",
+				"multiply_total_multiplicative",
+				"min_total",
+				"max_total",
+				"set_total"
 			]
 		},
 		"value": {
 			"description": "The value with which to apply the operation to the value.",
 			"type": "number"
 		},
+		"resource": {
+			"description": "If specified, the value of this power will be used instead of the value specified in the 'value' field.",
+			"$ref": "./identifier.json"
+		},
 		"name": {
 			"description": "A descriptive name for the modifier, describing where it comes from.",
 			"type": "string"
+		},
+		"modifier": {
+			"description": "If specified, this modifier will be applied to the value of the modifier.",
+			"$ref": "./attribute_modifier.json"
 		}
 	}
 }

--- a/schemas/types/attribute_modifier.json
+++ b/schemas/types/attribute_modifier.json
@@ -9,23 +9,71 @@
 	"properties": {
 		"operation": {
 			"description": "The operation which will be performed by this modifier.",
-			"enum": [
-				"addition",
-				"multiply_base",
-				"multiply_total",
-
-				"add_base_early",
-				"multiply_base_additive",
-				"multiply_base_multiplicative",
-				"add_base_late",
-				"min_base",
-				"max_base",
-				"set_base",
-				"multiply_total_additive",
-				"multiply_total_multiplicative",
-				"min_total",
-				"max_total",
-				"set_total"
+			"anyOf": [
+				{
+					"const": "addition",
+					"description": "Legacy: Adds (or subtracts) the modifier value to the base value. (NewValue = BaseValue + ModifierValue)"
+				},
+				{
+					"const": "multiply_base",
+					"description": "Legacy: Adds (or subtracts) the base value multiplied by the modifier value to the base value. (NewValue = BaseValue + (BaseValue * ModifierValue))"
+				},
+				{
+					"const": "multiply_total",
+					"description": "Legacy: Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
+				},
+				{
+					"const": "add_base_early",
+					"description": "Adds (or subtracts) the modifier value to the base value. (NewBaseValue = BaseValue + ModifierValue)"
+				},
+				{
+					"const": "multiply_base_additive",
+					"description": "Adds (or subtracts) the base value multiplied by the modifier value to the current base value. (NewBaseValue = BaseValue + (BaseValue * ModifierValue))"
+				},
+				{
+					"const": "multiply_base_multiplicative",
+					"description": "Multiplies the current base value by the modifier value. (NewBaseValue = BaseValue * (1 + ModifierValue))"
+				},
+				{
+					"const": "add_base_late",
+					"description": "Adds (or subtracts) the modifier value to the base value. (NewBaseValue = BaseValue + ModifierValue)"
+				},
+				{
+					"const": "min_base",
+					"description": "Uses the modifier value as the minimum value for the base value using Java's built-in Math#max method. (NewBaseValue = Math.max(BaseValue, ModifierValue))"
+				},
+				{
+					"const": "max_base",
+					"description": "Uses the modifier value as the maximum value for the base value using Java's built-in Math#min method. (NewBaseValue = Math.min(BaseValue, ModifierValue))"
+				},
+				{
+					"const": "set_base",
+					"description": "Sets the modifier value as the base value. (NewBaseValue = ModifierValue)"
+				},
+				{
+					"const": "multiply_total_additive",
+					"description": "Multiplies the total value by the current total value multiplied by the modifier value. (NewTotalValue = TotalValue * (TotalValue * ModifierValue))"
+				},
+				{
+					"const": "multiply_total_multiplicative",
+					"description": "Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
+				},
+				{
+					"const": "min_total",
+					"description": "Uses the modifier value as the minimum value for the total value using Java's built-in Math#max method. (NewTotalValue = Math.max(TotalValue, ModifierValue))"
+				},
+				{
+					"const": "max_total",
+					"description": "Uses the modifier value as the maximum value for the total value using Java's built-in Math#min method. (NewTotalValue = Math.min(TotalValue, ModifierValue))"
+				},
+				{
+					"const": "set_total",
+					"description": "Sets the modifier value as the total value. (NewTotalValue = ModifierValue)"
+				},
+				{
+					"const": "add_total_late",
+					"description": "Adds (or subtracts) the total value by the modifier value. (NewTotalValue = TotalValue + ModifierValue)"
+				}
 			]
 		},
 		"value": {
@@ -41,7 +89,7 @@
 			"type": "string"
 		},
 		"modifier": {
-			"description": "If specified, this modifier will be applied to the value of the modifier.",
+			"description": "If specified, this modifier will be applied to the value of the modifier.\"",
 			"$ref": "./attribute_modifier.json"
 		}
 	}

--- a/schemas/types/attribute_modifier_legacy.json
+++ b/schemas/types/attribute_modifier_legacy.json
@@ -1,0 +1,36 @@
+{
+	"$id": "https:\\snavesutit.github.io\\origins-mod-schemas\\types\\attribute_modifier_legacy.json",
+	"title": "Attribute Modifier (Legacy)",
+	"type": "object",
+	"required": [
+		"operation",
+		"value"
+	],
+	"properties": {
+		"operation": {
+			"description": "The operation which will be performed by this modifier.",
+			"anyOf": [
+				{
+					"const": "addition",
+					"description": "Adds (or subtracts) the modifier value to the base value. (NewValue = BaseValue + ModifierValue)"
+				},
+				{
+					"const": "multiply_base",
+					"description": "Adds (or subtracts) the base value multiplied by the modifier value to the base value. (NewValue = BaseValue + (BaseValue * ModifierValue))"
+				},
+				{
+					"const": "multiply_total",
+					"description": "Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
+				}
+			]
+		},
+		"value": {
+			"description": "The value with which to apply the operation to the value.",
+			"type": "number"
+		},
+		"name": {
+			"description": "A descriptive name for the modifier, describing where it comes from.",
+			"type": "string"
+		}
+	}
+}

--- a/schemas/types/attributed_attribute_modifier.json
+++ b/schemas/types/attributed_attribute_modifier.json
@@ -14,10 +14,19 @@
 		},
 		"operation": {
 			"description": "The operation which will be performed by this modifier.",
-			"enum": [
-				"addition",
-				"multiply_base",
-				"multiply_total"
+			"anyOf": [
+				{
+					"const": "addition",
+					"description": "Adds (or subtracts) the modifier value to the base value. (NewValue = BaseValue + ModifierValue)"
+				},
+				{
+					"const": "multiply_base",
+					"description": "Adds (or subtracts) the base value multiplied by the modifier value to the base value. (NewValue = BaseValue + (BaseValue * ModifierValue))"
+				},
+				{
+					"const": "multiply_total",
+					"description": "Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
+				}
 			]
 		},
 		"value": {

--- a/schemas/types/stat.json
+++ b/schemas/types/stat.json
@@ -1,0 +1,19 @@
+{
+	"$id": "https:\\snavesutit.github.io\\origins-mod-schemas\\types\\stat.json",
+	"title": "Stat",
+	"type": "object",
+	"required": [
+		"type",
+		"id"
+	],
+	"properties": {
+		"type": {
+			"description": "The type of the statistic.",
+			"$ref": "./identifier.json"
+		},
+		"id": {
+			"description": "The name of the statistic; may depend on the specified type of the statistic.",
+			"$ref": "./identifier.json"
+		}
+	}
+}

--- a/src/schemas/apoli/entity_actions/modify_stat.yml
+++ b/src/schemas/apoli/entity_actions/modify_stat.yml
@@ -19,7 +19,7 @@ properties:
       - origins:$fileName
 
   stat:
-    description: The namespace and ID of the statistic to be modified.
+    description: The type and name of the statistic to be modified.
     $ref: ../../types/stat.json
 
   modifier:

--- a/src/schemas/apoli/entity_actions/modify_stat.yml
+++ b/src/schemas/apoli/entity_actions/modify_stat.yml
@@ -20,7 +20,7 @@ properties:
 
   stat:
     description: The namespace and ID of the statistic to be modified.
-    $ref: ../../types/identifier.json
+    $ref: ../../types/stat.json
 
   modifier:
     description: This modifier will be applied to the current value of the statistic specified.

--- a/src/schemas/apoli/power_types/modify_food.yml
+++ b/src/schemas/apoli/power_types/modify_food.yml
@@ -30,23 +30,23 @@ properties:
 
   food_modifier:
     description: If specified, this modifier will apply to the food amount gained by eating a food item.
-    $ref: ../../types/attribute_modifier.json
+    $ref: ../../types/attribute_modifier_legacy.json
 
   food_modifiers:
     description: If specified, these modifiers will apply to the food amount gained by eating a food item.
     type: array
     items:
-      $ref: ../../types/attribute_modifier.json
+      $ref: ../../types/attribute_modifier_legacy.json
 
   saturation_modifier:
     description: If specified, this modifier will apply to the saturation amount gained by eating a food item.
-    $ref: ../../types/attribute_modifier.json
+    $ref: ../../types/attribute_modifier_legacy.json
 
   saturation_modifiers:
     description: If specified, these modifiers will apply to the saturation amount gained by eating a food item.
     type: array
     items:
-      $ref: ../../types/attribute_modifier.json
+      $ref: ../../types/attribute_modifier_legacy.json
 
   entity_action:
     description: If specified, this action will be executed on the player that has ate a food item.

--- a/src/schemas/apoli/power_types/modify_lava_speed.yml
+++ b/src/schemas/apoli/power_types/modify_lava_speed.yml
@@ -18,10 +18,10 @@ properties:
 
   modifier:
     description: If specified, this modifier will be applied to the movement speed while in lava.
-    $ref: ../../types/attribute_modifier.json
+    $ref: ../../types/attribute_modifier_legacy.json
 
   modifiers:
     description: If specified, these modifiers will be applied to the movement speed while in lava.
     type: array
     items:
-      $ref: ../../types/attribute_modifier.json
+      $ref: ../../types/attribute_modifier_legacy.json

--- a/src/schemas/apoli/power_types/modify_swim_speed.yml
+++ b/src/schemas/apoli/power_types/modify_swim_speed.yml
@@ -18,10 +18,10 @@ properties:
 
   modifier:
     description: If specified, this modifier will apply to the swim speed.
-    $ref: ../../types/attribute_modifier.json
+    $ref: ../../types/attribute_modifier_legacy.json
 
   modifiers:
     description: If specified, these modifiers will apply to the swim speed.
     type: array
     items:
-      $ref: ../../types/attribute_modifier.json
+      $ref: ../../types/attribute_modifier_legacy.json

--- a/src/schemas/types/attribute_modifier.yml
+++ b/src/schemas/types/attribute_modifier.yml
@@ -8,23 +8,40 @@ required:
 properties:
   operation:
     description: The operation which will be performed by this modifier.
-    enum:
-      - addition
-      - multiply_base
-      - multiply_total
+    anyOf:
+      - const: addition
+        description: "Legacy: Adds (or subtracts) the modifier value to the base value. (NewValue = BaseValue + ModifierValue)"
+      - const: multiply_base
+        description: "Legacy: Adds (or subtracts) the base value multiplied by the modifier value to the base value. (NewValue = BaseValue + (BaseValue * ModifierValue))"
+      - const: multiply_total
+        description: "Legacy: Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
 
-      - add_base_early
-      - multiply_base_additive
-      - multiply_base_multiplicative
-      - add_base_late
-      - min_base
-      - max_base
-      - set_base
-      - multiply_total_additive
-      - multiply_total_multiplicative
-      - min_total
-      - max_total
-      - set_total
+      - const: add_base_early
+        description: Adds (or subtracts) the modifier value to the base value. (NewBaseValue = BaseValue + ModifierValue)
+      - const: multiply_base_additive
+        description: Adds (or subtracts) the base value multiplied by the modifier value to the current base value. (NewBaseValue = BaseValue + (BaseValue * ModifierValue))
+      - const: multiply_base_multiplicative
+        description: Multiplies the current base value by the modifier value. (NewBaseValue = BaseValue * (1 + ModifierValue))
+      - const: add_base_late
+        description: Adds (or subtracts) the modifier value to the base value. (NewBaseValue = BaseValue + ModifierValue)
+      - const: min_base
+        description: Uses the modifier value as the minimum value for the base value using Java's built-in Math#max method. (NewBaseValue = Math.max(BaseValue, ModifierValue))
+      - const: max_base
+        description: Uses the modifier value as the maximum value for the base value using Java's built-in Math#min method. (NewBaseValue = Math.min(BaseValue, ModifierValue))
+      - const: set_base
+        description: Sets the modifier value as the base value. (NewBaseValue = ModifierValue)
+      - const: multiply_total_additive
+        description: Multiplies the total value by the current total value multiplied by the modifier value. (NewTotalValue = TotalValue * (TotalValue * ModifierValue))
+      - const: multiply_total_multiplicative
+        description: Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))
+      - const: min_total
+        description: Uses the modifier value as the minimum value for the total value using Java's built-in Math#max method. (NewTotalValue = Math.max(TotalValue, ModifierValue))
+      - const: max_total
+        description: Uses the modifier value as the maximum value for the total value using Java's built-in Math#min method. (NewTotalValue = Math.min(TotalValue, ModifierValue))
+      - const: set_total
+        description: Sets the modifier value as the total value. (NewTotalValue = ModifierValue)
+      - const: add_total_late
+        description: Adds (or subtracts) the total value by the modifier value. (NewTotalValue = TotalValue + ModifierValue)
 
   value:
     description: The value with which to apply the operation to the value.

--- a/src/schemas/types/attribute_modifier.yml
+++ b/src/schemas/types/attribute_modifier.yml
@@ -13,10 +13,31 @@ properties:
       - multiply_base
       - multiply_total
 
+      - add_base_early
+      - multiply_base_additive
+      - multiply_base_multiplicative
+      - add_base_late
+      - min_base
+      - max_base
+      - set_base
+      - multiply_total_additive
+      - multiply_total_multiplicative
+      - min_total
+      - max_total
+      - set_total
+
   value:
     description: The value with which to apply the operation to the value.
     type: number
 
+  resource:
+    description: If specified, the value of this power will be used instead of the value specified in the 'value' field.
+    $ref: ./identifier.json
+
   name:
     description: A descriptive name for the modifier, describing where it comes from.
     type: string
+
+  modifier:
+    description: If specified, this modifier will be applied to the value of the modifier."
+    $ref: ./attribute_modifier.json

--- a/src/schemas/types/attribute_modifier_legacy.yml
+++ b/src/schemas/types/attribute_modifier_legacy.yml
@@ -1,0 +1,25 @@
+$id: https://snavesutit.github.io/origins-mod-schemas/
+title: Attribute Modifier (Legacy)
+# description: An Object used to specify how an attribute should be modified.
+type: object
+required:
+  - operation
+  - value
+properties:
+  operation:
+    description: The operation which will be performed by this modifier.
+    anyOf:
+      - const: addition
+        description: "Adds (or subtracts) the modifier value to the base value. (NewValue = BaseValue + ModifierValue)"
+      - const: multiply_base
+        description: "Adds (or subtracts) the base value multiplied by the modifier value to the base value. (NewValue = BaseValue + (BaseValue * ModifierValue))"
+      - const: multiply_total
+        description: "Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
+
+  value:
+    description: The value with which to apply the operation to the value.
+    type: number
+
+  name:
+    description: A descriptive name for the modifier, describing where it comes from.
+    type: string

--- a/src/schemas/types/attributed_attribute_modifier.yml
+++ b/src/schemas/types/attributed_attribute_modifier.yml
@@ -13,10 +13,13 @@ properties:
 
   operation:
     description: The operation which will be performed by this modifier.
-    enum:
-      - addition
-      - multiply_base
-      - multiply_total
+    anyOf:
+      - const: addition
+        description: "Adds (or subtracts) the modifier value to the base value. (NewValue = BaseValue + ModifierValue)"
+      - const: multiply_base
+        description: "Adds (or subtracts) the base value multiplied by the modifier value to the base value. (NewValue = BaseValue + (BaseValue * ModifierValue))"
+      - const: multiply_total
+        description: "Multiplies the total value by the modifier value + 1. (NewTotalValue = TotalValue * (1 + ModifierValue))"
 
   value:
     description: The value with which to apply the operation to the value.

--- a/src/schemas/types/stat.yml
+++ b/src/schemas/types/stat.yml
@@ -1,0 +1,14 @@
+$id: https://snavesutit.github.io/origins-mod-schemas/
+title: Stat
+# description: An object specifying a statistic via a statistic type and an identifier.
+type: object
+required:
+  - type
+  - id
+properties:
+  type:
+    description: The type of the statistic.
+    $ref: ./identifier.json
+  id:
+    description: The name of the statistic; may depend on the specified type of the statistic.
+    $ref: ./identifier.json


### PR DESCRIPTION
Added missing Attribute Modifiers to `attribute_modifier` and powers/actions that depend on old (legacy) ones now use the new `attribute_modifier_legacy` data type
Added descriptions for Attribute Modifiers in `attribute_modifier`, `attribute_modifier_legacy` and `attributed_attribute_modifier`
Fixed `origins:modify_stat` `stat` field needing a `string` even though it actually uses an `object` (added `stat` data type)